### PR TITLE
power-libperfmgr: Add support for tap-to-wake feature control

### DIFF
--- a/aidl/power-libperfmgr/Android.mk
+++ b/aidl/power-libperfmgr/Android.mk
@@ -47,6 +47,10 @@ ifneq ($(TARGET_POWERHAL_MODE_EXT),)
     LOCAL_SRC_FILES += ../../../../$(TARGET_POWERHAL_MODE_EXT)
 endif
 
+ifneq ($(TARGET_TAP_TO_WAKE_NODE),)
+    LOCAL_CFLAGS += -DTAP_TO_WAKE_NODE=\"$(TARGET_TAP_TO_WAKE_NODE)\"
+endif
+
 LOCAL_MODULE := android.hardware.power-service.xiaomi-libperfmgr
 LOCAL_INIT_RC := android.hardware.power-service.xiaomi-libperfmgr.rc
 LOCAL_MODULE_TAGS := optional

--- a/aidl/power-libperfmgr/Power.cpp
+++ b/aidl/power-libperfmgr/Power.cpp
@@ -87,6 +87,11 @@ ndk::ScopedAStatus Power::setMode(Mode type, bool enabled) {
     }
 #endif
     switch (type) {
+#ifdef TAP_TO_WAKE_NODE
+        case Mode::DOUBLE_TAP_TO_WAKE:
+            ::android::base::WriteStringToFile(enabled ? "1" : "0", TAP_TO_WAKE_NODE, true);
+            break;
+#endif
         case Mode::SUSTAINED_PERFORMANCE:
             if (enabled) {
                 mHintManager->DoHint("SUSTAINED_PERFORMANCE");
@@ -98,8 +103,10 @@ ndk::ScopedAStatus Power::setMode(Mode type, bool enabled) {
                 break;
             }
             [[fallthrough]];
+#ifndef TAP_TO_WAKE_NODE
         case Mode::DOUBLE_TAP_TO_WAKE:
             [[fallthrough]];
+#endif
         case Mode::FIXED_PERFORMANCE:
             [[fallthrough]];
         case Mode::EXPENSIVE_RENDERING:
@@ -132,6 +139,11 @@ ndk::ScopedAStatus Power::isModeSupported(Mode type, bool *_aidl_return) {
 #endif
 
     bool supported = mHintManager->IsHintSupported(toString(type));
+#ifdef TAP_TO_WAKE_NODE
+    if (type == Mode::DOUBLE_TAP_TO_WAKE) {
+        supported = true;
+    }
+#endif
     LOG(INFO) << "Power mode " << toString(type) << " isModeSupported: " << supported;
     *_aidl_return = supported;
     return ndk::ScopedAStatus::ok();


### PR DESCRIPTION
[wight554] Enable DOUBLE_TAP_TO_WAKE mode explicitly and move dt2w mode on top of setMode switch: when LAUNCH hint is received, if mSustainedPerfModeOn is not true, it will not break, leading to the case switch going through all the next labels without interrupting until the end, also hitting DT2W one, leading to DT2W always toggling when you launch an app
[SebaUbuntu] Don't break devices using hint manager for DT2W toggle

Change-Id: Ib6e1e010834b1b16668d52db79b26804fe0e1671